### PR TITLE
test_molden2qmc: Solve issue with new version of numpy

### DIFF
--- a/test_molden2qmc.py
+++ b/test_molden2qmc.py
@@ -10,7 +10,7 @@ import molden2qmc
 
 molden2qmc.__version__ = __version__
 
-np.set_printoptions(threshold=np.nan, suppress=True, linewidth=10000)
+np.set_printoptions(threshold=np.inf, suppress=True, linewidth=10000)
 
 
 def mo_matrix(m, col=0, skip=4):


### PR DESCRIPTION
Using `test_molden2qmc` with crrent version of numpy `1.17.3` raise:

```
Traceback (most recent call last):
  File "./test_molden2qmc.py", line 13, in <module>
    np.set_printoptions(threshold=np.nan, suppress=True, linewidth=10000)
  File "/Users/tapplencourt/miniconda/miniconda3/lib/python3.7/site-packages/numpy/core/arrayprint.py", line 247, in set_printoptions
    floatmode, legacy)
  File "/Users/tapplencourt/miniconda/miniconda3/lib/python3.7/site-packages/numpy/core/arrayprint.py", line 93, in _make_options_dict
    raise ValueError("threshold must be numeric and non-NAN, try "
ValueError: threshold must be numeric and non-NAN, try sys.maxsize for untruncated representation
```

This is caused by `np.set_printoptions(threshold=np.nan, suppress=True, linewidth=10000)
` and more precisely by `threshold=np.nan`.  Replacing `np.nan` by `np.inf` solve the issue.

(Strangely enought, It looks like `np.nan` was never supported...  For more information https://github.com/numpy/numpy/issues/12987 ).